### PR TITLE
Soporte para Vectores 3D

### DIFF
--- a/src/main/scala/org/uqbar/math/vectors/Axis.scala
+++ b/src/main/scala/org/uqbar/math/vectors/Axis.scala
@@ -1,0 +1,30 @@
+package org.uqbar.math.vectors
+
+trait Axis {
+  def getFrom(v:Vector): Double
+  def setOn(arg: AbstractMutableVector, v: Double)
+}
+
+object Axis {
+  
+  case object X extends Axis {
+    def getFrom(v:Vector) = v.x
+    def setOn(arg: AbstractMutableVector, v: Double) = {
+      arg.x = v
+    }
+  }
+  case object Y extends Axis {
+    def getFrom(v:Vector) = v.y
+    def setOn(arg: AbstractMutableVector, v: Double) = {
+      arg.y = v
+    }
+  }
+  case object Z extends Axis {
+    def getFrom(v:Vector) = v.z
+    def setOn(arg: AbstractMutableVector, v: Double) = {
+      arg.z = v
+    }
+  }
+  
+  val axes = Array(X, Y, Z)
+}

--- a/src/main/scala/org/uqbar/math/vectors/Vector.scala
+++ b/src/main/scala/org/uqbar/math/vectors/Vector.scala
@@ -2,140 +2,241 @@ package org.uqbar.math.vectors
 
 import scala.math.acos
 import scala.math.sqrt
+import scala.collection.mutable.AnyRefMap
+import scala.collection.mutable.Map
 
 trait Vector {
 
-	def x: Double
-	def y: Double
+  def x: Double
+  def y: Double
+  //It is very convenient to have all vectors understand z
+  def z: Double
+  
+  //*********************************************************************************************
+  // QUERYING
+  //*********************************************************************************************
 
-	//*********************************************************************************************
-	// BASIC OPERATIONS
-	//*********************************************************************************************
+  def apply(ax: Axis) = {
+    ax.getFrom(this)
+  }
+  /**
+   * Returns the list of the components of this vector, ordered by X, Y
+   */
+  def components: Seq[Double] = axes.map(_.getFrom(this))
+  
+  /**
+   * Returns a map of the components
+   */
+  def componentsMap:Map[Axis, Double] = AnyRefMap(axes.zip(components):_*)
 
-	/**
-	 * Returns the inverse of this vector.
-	 *
-	 * The inverse of a vector is another vector with the same magnitude but opposite direction.
-	 * This method is equivalent to evaluating this * -1.
-	 */
-	def unary_- = this * -1
+  def axes: Seq[Axis]
 
-	/**
-	 * Returns the addition of this vector and the one received.
-	 */
-	def +(v: Vector): Vector = (x + v.x, y + v.y)
-	/**
-	 * Returns the subtraction from this vector of the one received.
-	 */
-	def -(v: Vector): Vector = (x - v.x, y - v.y)
-	/**
-	 * Returns the dot product between this vector and the one received.
-	 */
-	def °(v: Vector): Double = x * v.x + y * v.y
-	/**
-	 * Returns the scalar product between this vector and the scalar received.
-	 */
-	def *(d: Double): Vector = (x * d, y * d)
-	/**
-	 * Returns the scalar division between this vector and the scalar received.
-	 */
-	def /(d: Double): Vector = (x / d, y / d)
+  //*********************************************************************************************
+  // BASIC OPERATIONS
+  //*********************************************************************************************
 
-	/**
-	 * Returns the module (or magnitude) of this vector.
-	 */
-	def module = sqrt(x * x + y * y)
+  /**
+   * Returns the inverse of this vector.
+   *
+   * The inverse of a vector is another vector with the same magnitude but opposite direction.
+   * This method is equivalent to evaluating this * -1.
+   */
+  def unary_- = this * -1
 
-	/**
-	 * Returns a vector with the same direction as this, but magnitude 1.
-	 */
-	def asVersor = this / module
+  /**
+   * Returns the addition of this vector and the one received.
+   */
+  def +(v: Vector): Vector = zipWith(_ + _)(v)
+  /**
+   * Returns the subtraction from this vector of the one received.
+   */
+  def -(v: Vector): Vector = zipWith(_ - _)(v)
+  /**
+   * Returns the dot product between this vector and the one received.
+   */
+  def °(v: Vector): Double = zipWith(_ * _)(v).reduce(_ + _)
+  /**
+   * Returns the scalar product between this vector and the scalar received.
+   */
+  def *(d: Double): Vector = map(_ * d)
 
-	//*********************************************************************************************
-	// HIGHER-ORDER OPERATIONS
-	//*********************************************************************************************
+  /**
+   * Returns the scalar division between this vector and the scalar received.
+   */
+  def /(d: Double): Vector = map(_ / d)
 
-	/**
-	 * Returns the vector resultant of applying a function to every dimension value.
-	 */
-	def map(f: Double ⇒ Double): Vector = (f(x), f(y))
-	/**
-	 * Returns a vector composed of the result of applying the given function to every dimension of booth this vector and the one received.
-	 */
-	def zipWith(f: (Double, Double) ⇒ Double)(v: Vector): Vector = (f(x, v.x), f(y, v.y))
+  /**
+   * Returns the module (or magnitude) of this vector.
+   */
+  def module = sqrt(dotSelf)
 
-	//*********************************************************************************************
-	// COMPARATIONS
-	//*********************************************************************************************
+  /**
+   * Applies dot product (°) to itself. Equivalent to this ° this
+   */
+  def dotSelf = this ° this
 
-	/**
-	 * Returns the angle between this vector and the one received.
-	 */
-	def angleTo(v: Vector) = acos(asVersor ° v.asVersor)
+  /**
+   * Returns a vector with the same direction as this, but magnitude 1.
+   */
+  def asVersor = this / module
 
-	/**
-	 * Returns a vector composed of the minimum value for every dimension between this vector and the one received.
-	 */
-	def min(v: Vector) = zipWith(_ min _)(v)
-	/**
-	 * Returns a vector composed of the minimum value for every dimension between this vector and the one received.
-	 */
-	def max(v: Vector) = zipWith(_ max _)(v)
+  //*********************************************************************************************
+  // HIGHER-ORDER OPERATIONS. These have to be redefined for every dimension added.
+  //*********************************************************************************************
 
-	//*********************************************************************************************
-	// DISTANCE
-	//*********************************************************************************************
+  /**
+   * Returns the vector resultant of applying a function to every dimension value.
+   */
+  //These operations could be more "generic" if we used collections, but collections are very slow in comparison with variables
+  def map(f: Double ⇒ Double): Vector = (f(x), f(y))
 
-	/**
-	 * Returns the distance from this vector to the received one, booth interpreted as a points.
-	 */
-	def distanceTo(v: Vector) = (this - v).module
+  /**
+   * Returns a vector composed of the result of applying the given function to every dimension of booth this vector and the one received.
+   */
+  def zipWith(f: (Double, Double) ⇒ Double)(v: Vector): Vector = (f(x, v.x), f(y, v.y))
 
-	/**
-	 * Returns the square of the distance from this vector to the received one, booth interpreted as a points.
-	 */
-	def squareDistanceTo(p: Vector) = {
-		val v = (p - this)
-		v.x * v.x + v.y * v.y
-	}
+  /**
+   * Operates over the components of this vector to produce a scalar
+   */
+  def reduce[T <% Double](f: (Double, Double) ⇒ T): T = f(x, y)
 
-	/**
-	 * Returns the Manhattan distance from this vector to the received one, booth interpreted as a points.
-	 */
-	def manhattanDistanceTo(v: Vector) = (x - v.x).toInt.abs + (y - v.y).toInt.abs
+  //*********************************************************************************************
+  // COMPARATIONS
+  //*********************************************************************************************
 
-	//*********************************************************************************************
-	// PRINTING
-	//*********************************************************************************************
+  /**
+   * Returns the angle between this vector and the one received.
+   */
+  def angleTo(v: Vector) = acos(asVersor ° v.asVersor)
 
-	override def toString = (x, y).toString
+  /**
+   * Returns a vector composed of the minimum value for every dimension between this vector and the one received.
+   */
+  def min(v: Vector) = zipWith(_ min _)(v)
+  /**
+   * Returns a vector composed of the minimum value for every dimension between this vector and the one received.
+   */
+  def max(v: Vector) = zipWith(_ max _)(v)
+
+  //*********************************************************************************************
+  // DISTANCE
+  //*********************************************************************************************
+
+  /**
+   * Returns the distance from this vector to the received one, booth interpreted as a points.
+   */
+  def distanceTo(v: Vector) = (this - v).module
+
+  /**
+   * Returns the square of the distance from this vector to the received one, booth interpreted as a points.
+   */
+  def squareDistanceTo(p: Vector) = {
+    (p - this).dotSelf
+  }
+
+  /**
+   * Returns the Manhattan distance from this vector to the received one, booth interpreted as a points.
+   */
+  def manhattanDistanceTo(v: Vector) = (this - v).reduce(_.toInt.abs + _.toInt.abs)
+
+  //*********************************************************************************************
+  // PRINTING
+  //*********************************************************************************************
+
+  override def toString = (x, y).toString
+
+  //*********************************************************************************************
+  // CLONING
+  //********************************************************************************************* 
+  def copy: this.type
+  
 }
 
-case class MutableVector(var x: Double, var y: Double) extends Vector {
-	/**
-	 * Sets this vector dimension values to the same ones as the vector given.
-	 */
-	def set(v: Vector) = {
-		this.x = v.x
-		this.y = v.y
-		this
-	}
+trait AbstractMutableVector extends Vector {
+  def set(v: Vector): AbstractMutableVector = {
+    set(v.x, v.y, v.z)
+  }
 
-	/**
-	 * Updates this vector to be equal to the result of the addition between itself and the one received.
-	 */
-	def +=(v: Vector) = set(x + v.x, y + v.y)
-	/**
-	 * Updates this vector to be equal to the result of the subtraction between itself and the one received.
-	 */
-	def -=(v: Vector) = set(x - v.x, y - v.y)
-	/**
-	 * Updates this vector to be equal to the result of the scalar product between itself and the scalar received.
-	 */
-	def *=(d: Double) = set(x * d, y * d)
-	/**
-	 * Updates this vector to be equal to the result of the scalar division between itself and the scalar received.
-	 */
-	def /=(d: Double) = set(x / d, y / d)
+  def set(someX: Double, someY: Double, someZ: Double = 0): AbstractMutableVector = {
+    this.x = someX
+    this.y = someY
+    this.z = someZ
+    this
+  }
+  
+  def setAxis(ax: Axis, v: Double) = ax.setOn(this, v)
 
+  def x_=(someX: Double): Unit
+  def y_=(someY: Double): Unit
+  def z_=(someZ: Double): Unit
+
+  def operateWith(op: (Double, Double) ⇒ Double)(v: Vector) = set(op(x, v.x), op(y, v.y))
+
+  def mapSet(op: Double ⇒ Double) = set(op(x), op(y))
+
+  /**
+   * Updates this vector to be equal to the result of the addition between itself and the one received.
+   */
+  def +=(v: Vector) = operateWith(_ + _)(v)
+
+  /**
+   * Updates this vector to be equal to the result of the subtraction between itself and the one received.
+   */
+  def -=(v: Vector) = operateWith(_ - _)(v)
+  /**
+   * Updates this vector to be equal to the result of the scalar product between itself and the scalar received.
+   */
+  def *=(d: Double) = mapSet(_ * d)
+  /**
+   * Updates this vector to be equal to the result of the scalar division between itself and the scalar received.
+   */
+  def /=(d: Double) = mapSet(_ / d)
+
+}
+
+case class MutableVector(var x: Double, var y: Double) extends AbstractMutableVector {
+  /**
+   * Sets this vector dimension values to the same ones as the vector given.
+   */
+
+  /**
+   * On 2d Vectors, z is always 0
+   */
+  def z = 0;
+  
+  //Why array? Because benchmarks shows that it is created around three times faster than other sequences, and, when small, iterated around 50% faster
+  def axes = Array(Axis.X, Axis.Y)
+
+  /* NADA. Quizás conviene pensar un mecanismo por el cual un vector bidimensional
+   * pueda convertirse en un vector tridimensional. La idea sería que ignore la componente z
+   * hasta que se le asigne un valor. Si se lo piden explícitamente, el valor de la componente es 0,
+   * por conveniencia, pero al sumar, restar, hacer dot product y todo eso, quiero ignorarlo.
+   */
+  def z_=(someZ: Double): Unit = {}
+
+  def copy: this.type = MutableVector(x, y).asInstanceOf[this.type]
+}
+
+case class MutableVector3D(var x: Double, var y: Double, var z: Double) extends AbstractMutableVector {
+  def axes = Array(Axis.X, Axis.Y, Axis.Z)
+  
+  override def toString = (x, y, z).toString
+
+  override def map(f: Double ⇒ Double): Vector = (f(x), f(y), f(z))
+
+  /**
+   * Returns a vector composed of the result of applying the given function to every dimension of booth this vector and the one received.
+   */
+  override def zipWith(f: (Double, Double) ⇒ Double)(v: Vector): Vector = (f(x, v.x), f(y, v.y), f(z, v.z))
+
+  /**
+   * Operates over the components of this vector to produce a scalar
+   */
+  override def reduce[T <% Double](f: (Double, Double) ⇒ T): T = f(f(x, y), z)
+
+  override def operateWith(op: (Double, Double) ⇒ Double)(v: Vector) = set(op(x, v.x), op(y, v.y), op(z, v.z))
+
+  override def mapSet(op: Double ⇒ Double) = set(op(x), op(y), op(z))
+  
+  def copy: this.type = MutableVector3D(x, y, z).asInstanceOf[this.type]
 }

--- a/src/main/scala/org/uqbar/math/vectors/Vector.scala
+++ b/src/main/scala/org/uqbar/math/vectors/Vector.scala
@@ -79,6 +79,12 @@ trait Vector {
    * Returns a vector with the same direction as this, but magnitude 1.
    */
   def asVersor = this / module
+  
+  /**
+   * Returns a vector that is the result of applying cross product of this vector with the other.
+   * Note that in 2D vectors, z is assumed to be 0
+   */
+  def x(v: Vector):Vector = (y * v.z - z * v.y, z * v.x - x * v.z, x * v.y - y * v.x)
 
   //*********************************************************************************************
   // HIGHER-ORDER OPERATIONS. These have to be redefined for every dimension added.

--- a/src/main/scala/org/uqbar/math/vectors/package.scala
+++ b/src/main/scala/org/uqbar/math/vectors/package.scala
@@ -5,10 +5,12 @@ import java.awt.{ Point => AWTPoint, Dimension => AWTDimension }
 
 package object vectors {
 	val Origin: Vector = (0, 0)
+  val Origin3D : Vector = (0, 0, 0)
 
 	def random: Vector = (Math.random, Math.random)
 
 	implicit def Touple_to_Vector[T <% Double, U <% Double](t: (T, U)): MutableVector = MutableVector(t._1, t._2)
+  implicit def Touple_to_Vector3D[T <% Double, U <% Double, V <% Double](t: (T, U, V)): MutableVector3D = MutableVector3D(t._1, t._2, t._3)
 	implicit def Vector_to_Touple(v: Vector): (Double, Double) = (v.x, v.y)
 
 	implicit def Point_to_Vector(p: AWTPoint): Vector = (p.x, p.y)

--- a/src/test/scala/org/uqbar/math/vectors/VectorTest.scala
+++ b/src/test/scala/org/uqbar/math/vectors/VectorTest.scala
@@ -16,6 +16,23 @@ class VectorTest extends FreeSpec with Matchers {
                            origin: Vector, distanceDestination: Vector, distance: Double, manhattanDistance: Double)
 
   "vector" - {
+    
+    "queries" -{
+      val v: Vector = (1,2,3)
+      
+      "should be able to query by axis" in {
+        v(Axis.X) should be(v.x)
+        v(Axis.Y) should be(v.y)
+        v(Axis.Z) should be(v.z)
+      }
+      
+      "should be able to get the list of components" in {
+        v.components should equal(Seq(1,2,3))
+        v.componentsMap should equal(Map((Axis.X,1),(Axis.Y,2),(Axis.Z,3)))
+      }
+      
+    }
+    
     val valuesFor2D = TestSetValues("2D", (4, 5), (4, 5), (4, 5), (1, 6), (-1.5, 3), (0, 0), (5, 3), 5, 4)
     val valuesFor3D = TestSetValues("3D", (4, 5, 6), (4, 5, 6), (4, 5, 6), (1, 6, 1), (-1.5, 3, 4), (0, 0, 0), (5, 10, 8), 9, 9)
 

--- a/src/test/scala/org/uqbar/math/vectors/VectorTest.scala
+++ b/src/test/scala/org/uqbar/math/vectors/VectorTest.scala
@@ -16,23 +16,23 @@ class VectorTest extends FreeSpec with Matchers {
                            origin: Vector, distanceDestination: Vector, distance: Double, manhattanDistance: Double)
 
   "vector" - {
-    
-    "queries" -{
-      val v: Vector = (1,2,3)
-      
+
+    "queries" - {
+      val v: Vector = (1, 2, 3)
+
       "should be able to query by axis" in {
         v(Axis.X) should be(v.x)
         v(Axis.Y) should be(v.y)
         v(Axis.Z) should be(v.z)
       }
-      
+
       "should be able to get the list of components" in {
-        v.components should equal(Seq(1,2,3))
-        v.componentsMap should equal(Map((Axis.X,1),(Axis.Y,2),(Axis.Z,3)))
+        v.components should equal(Seq(1, 2, 3))
+        v.componentsMap should equal(Map((Axis.X, 1), (Axis.Y, 2), (Axis.Z, 3)))
       }
-      
+
     }
-    
+
     val valuesFor2D = TestSetValues("2D", (4, 5), (4, 5), (4, 5), (1, 6), (-1.5, 3), (0, 0), (5, 3), 5, 4)
     val valuesFor3D = TestSetValues("3D", (4, 5, 6), (4, 5, 6), (4, 5, 6), (1, 6, 1), (-1.5, 3, 4), (0, 0, 0), (5, 10, 8), 9, 9)
 
@@ -49,7 +49,7 @@ class VectorTest extends FreeSpec with Matchers {
       val v: Vector = values.v
       val w: Vector = values.w
       val Origin = values.origin
-      
+
       values.context - {
         "equality" - {
           "should be consistent" in { v should not(be(null) or be("foo")) }
@@ -128,6 +128,29 @@ class VectorTest extends FreeSpec with Matchers {
           "to self should be 0" in { v manhattanDistanceTo v should be(0.0) }
         }
       }
+
+    }
+
+    "cross product" - {
+      val u: Vector = (3, 4 ,7)
+      val v: Vector = (1, 2, 4)
+      val w: Vector = (2, 1, 3)
+      val λ = 2.0
+      
+      "should compute well" in { u x v should equal(2, -5, 2) }
+      "module should be equal to alternative calculation" in { (u x v).module should equal(u.module * v.module * Math.sin(u.angleTo(v)))}
+      "should be anticommutative" in { u x v should equal (-v x u) }
+      "should be distributive over adition" in {u x (v + w) should equal ((u x v) + (u x w))}
+      "should be compatible with scalar multiplication" in {
+        (λ * u) x v should equal (u x (λ * v))
+        (λ * u) x v should equal (λ * (u x v))
+      }
+      "should produce orthogonal vector" in {
+        val r = u x v
+        r.angleTo(v) should equal (Math.PI / 2)
+        r.angleTo(u) should equal (Math.PI / 2)
+      }
+      
     }
   }
 
@@ -140,10 +163,10 @@ class VectorTest extends FreeSpec with Matchers {
   implicit val VectorEquality = new Equality[Vector] {
     def areEqual(v: Vector, o: Any) = {
       o match {
-        case (x: Number, y: Number) => x.doubleValue === v.x.doubleValue +- tolerance && y.doubleValue === v.y.doubleValue +- tolerance
-        case (x: Number, y: Number, z:Number) => x.doubleValue === v.x.doubleValue +- tolerance && y.doubleValue === v.y.doubleValue +- tolerance && z.doubleValue === v.z.doubleValue +- tolerance
-        case u: Vector              => u.x.doubleValue === v.x.doubleValue +- tolerance && u.y.doubleValue === v.y.doubleValue +- tolerance
-        case _                      => false
+        case (x: Number, y: Number)            => x.doubleValue === v.x.doubleValue +- tolerance && y.doubleValue === v.y.doubleValue +- tolerance
+        case (x: Number, y: Number, z: Number) => x.doubleValue === v.x.doubleValue +- tolerance && y.doubleValue === v.y.doubleValue +- tolerance && z.doubleValue === v.z.doubleValue +- tolerance
+        case u: Vector                         => u.x.doubleValue === v.x.doubleValue +- tolerance && u.y.doubleValue === v.y.doubleValue +- tolerance
+        case _                                 => false
       }
     }
   }

--- a/src/test/scala/org/uqbar/math/vectors/VectorTest.scala
+++ b/src/test/scala/org/uqbar/math/vectors/VectorTest.scala
@@ -8,121 +8,135 @@ import org.scalatest.matchers.MatchResult
 
 class VectorTest extends FreeSpec with Matchers {
 
-	//*********************************************************************************************
-	// TEST CASES
-	//*********************************************************************************************
+  //*********************************************************************************************
+  // TEST CASES
+  //*********************************************************************************************
 
-	"vector" - { 
-		val u: Vector = (4, 5)
-		val u2: Vector = (4, 5)
-		val u3: Vector = (4, 5)
-		val v: Vector = (1, 6)
-		val w: Vector = (-1.5, 3)
-		val λ = 2.0
-		val µ = 5.5
+  case class TestSetValues(context: String, u: Vector, u2: Vector, u3: Vector, v: Vector, w: Vector,
+                           origin: Vector, distanceDestination: Vector, distance: Double, manhattanDistance: Double)
 
-		"Origin should be (0,0)" in { Origin should equal (0, 0) }
+  "vector" - {
+    val valuesFor2D = TestSetValues("2D", (4, 5), (4, 5), (4, 5), (1, 6), (-1.5, 3), (0, 0), (5, 3), 5, 4)
+    val valuesFor3D = TestSetValues("3D", (4, 5, 6), (4, 5, 6), (4, 5, 6), (1, 6, 1), (-1.5, 3, 4), (0, 0, 0), (5, 10, 8), 9, 9)
 
-		"equality" - {
-			"should be consistent" in { v should not (be (null) or be ("foo")) }
-			"should be reflexive" in { v should be (v) }
-			"should be symmetric" in {
-				u should be (u2)
-				u2 should be (u)
-			}
-			"should be transitive" in {
-				u should be (u2)
-				u2 should be (u3)
-				u should be (u3)
-			}
-		}
+    "Origin should be (0,0)" in { Origin should equal(0, 0) }
+    "Origin3D should be (0,0,0)" in { Origin3D should equal(0, 0, 0) }
 
-		"hash should be consistent" in { u2.hashCode should be (u.hashCode) }
+    val λ = 2.0
+    val µ = 5.5
 
-		"opposite should be (-x,-y)" in { -v should equal (-v.x, -v.y) }
+    for (values <- List(valuesFor2D, valuesFor3D)) {
+      val u: Vector = values.u
+      val u2: Vector = values.u2
+      val u3: Vector = values.u3
+      val v: Vector = values.v
+      val w: Vector = values.w
+      val Origin = values.origin
+      
+      values.context - {
+        "equality" - {
+          "should be consistent" in { v should not(be(null) or be("foo")) }
+          "should be reflexive" in { v should be(v) }
+          "should be symmetric" in {
+            u should be(u2)
+            u2 should be(u)
+          }
+          "should be transitive" in {
+            u should be(u2)
+            u2 should be(u3)
+            u should be(u3)
+          }
+        }
 
-		"addition" - {
-			"should compute well" in { u + v should equal (u.x + v.x, u.y + v.y) }
-			"should be commutative" in { u + v should be (v + u) }
-			"should be associative" in { u + v + w should (be ((u + v) + w) and be (u + (v + w))) }
-			"should have Origin as identity element" in { v + Origin should be (v) }
-			"against opposite should yield Origin" in { v + -v should be (Origin) }
-		}
+        "hash should be consistent" in { u2.hashCode should be(u.hashCode) }
 
-		"subtraction" - {
-			"should compute well" in { u - v should equal (u.x - v.x, u.y - v.y) }
-			"should be same as addition with opposite" in { u - v should be (u + -v) }
-			"should have Origin as identity element" in { v - Origin should be (v) }
-		}
+        "opposite should be (-x,-y, z)" in { -v should equal(-v.x, -v.y, -v.z) }
 
-		"scalar multiplication" - {
-			"should compute well" in { v * λ should equal(v.x * λ, v.y * λ) }
-			"should be additive" in { (u + v) * λ should be(u * λ + v * λ) }
-			"should be compatible" in { v * (λ * µ) should be((v * λ) * µ) }
-			"should be symmetric" in { λ * v should be(v * λ) }
-			"should have 1 as identity element" in { v * 1 should be(v) }
-			"should have 0 as absorbent element" in { v * 0 should be(Origin) }
-			"against -1 should yield opposite" in { v * -1 should be (-v) }
-		}
+        "addition" - {
+          "should compute well" in { (u + v).components should equal(u.components.zip(v.components).map(t => t._1 + t._2)) }
+          "should be commutative" in { u + v should be(v + u) }
+          "should be associative" in { u + v + w should (be((u + v) + w) and be(u + (v + w))) }
+          "should have Origin as identity element" in { v + Origin should be(v) }
+          "against opposite should yield Origin" in { v + -v should be(Origin) }
+        }
 
-		"scalar division" - {
-			"should compute well" in { v / λ should equal(v.x / λ, v.y / λ) }
-			"should be equal to the product with scalar inverse" in { v / λ should be(v * 1 / λ) }
-			"should be symmetric" in { λ / v should be(v / λ) }
-		}
+        "subtraction" - {
+          "should compute well" in { (u - v).components should equal(u.components.zip(v.components).map(t => t._1 - t._2)) }
+          "should be same as addition with opposite" in { u - v should be(u + -v) }
+          "should have Origin as identity element" in { v - Origin should be(v) }
+        }
 
-		"dot product should compute well" in {
-			v ° u should be(v.x * u.x + v.y * u.y)
-			v ° u should equal (v.module * u.module * cos(v.angleTo(u)))
-		}
+        "scalar multiplication" - {
+          "should compute well" in { (v * λ).components should equal(v.components.map(_ * λ)) }
+          "should be additive" in { (u + v) * λ should be(u * λ + v * λ) }
+          "should be compatible" in { v * (λ * µ) should be((v * λ) * µ) }
+          "should be symmetric" in { λ * v should be(v * λ) }
+          "should have 1 as identity element" in { v * 1 should be(v) }
+          "should have 0 as absorbent element" in { v * 0 should be(Origin) }
+          "against -1 should yield opposite" in { v * -1 should be(-v) }
+        }
 
-		"module should compute well" in { v.module should be (sqrt(v.x * v.x + v.y * v.y)) }
+        "scalar division" - {
+          "should compute well" in { v / λ should equal(v.x / λ, v.y / λ) }
+          "should be equal to the product with scalar inverse" in { v / λ should be(v * 1 / λ) }
+          "should be symmetric" in { λ / v should be(v / λ) }
+        }
 
-		"as versor should have module 1" in { v.asVersor.module should be (1.0) }
+        "dot product should compute well" in {
+          v ° u should be(v.x * u.x + v.y * u.y + v.z * u.z) //Funciona porque z es 0 para los 2d
+          v ° u should equal(v.module * u.module * cos(v.angleTo(u)))
+        }
 
-		"distance" - {
-			"should compute well" in { v distanceTo (5, 3) should be (5.0) }
-			"should be symmetric" in { v distanceTo u should be (u distanceTo v) }
-			"to Origin should be the vector module" in { v distanceTo Origin should equal (v.module) }
-			"to self should be 0" in { v distanceTo v should be (0.0) }
-		}
+        "module should compute well" in { v.module should be(sqrt(v.components.fold(0d)((acum, elem) => acum + elem * elem))) }
 
-		"square distance" - {
-			"should compute well" in { v squareDistanceTo u should equal (pow(v distanceTo u, 2)) }
-			"should be symmetric" in { v squareDistanceTo u should be (u squareDistanceTo v) }
-			"to Origin should be the square of the vector module" in { v squareDistanceTo Origin should equal (pow(v.module, 2)) }
-			"to self should be 0" in { v squareDistanceTo v should be (0.0) }
-		}
+        "as versor should have module 1" in { v.asVersor.module should be(1.0) }
 
-		"manhattan distance" - {
-			"should compute well" in { v manhattanDistanceTo u should be (4) }
-			"should be symmetric" in { v manhattanDistanceTo u should be (u manhattanDistanceTo v) }
-			"to self should be 0" in { v manhattanDistanceTo v should be (0.0) }
-		}
-	}
+        "distance" - {
+          "should compute well" in { v distanceTo values.distanceDestination should be(values.distance) }
+          "should be symmetric" in { v distanceTo u should be(u distanceTo v) }
+          "to Origin should be the vector module" in { v distanceTo Origin should equal(v.module) }
+          "to self should be 0" in { v distanceTo v should be(0.0) }
+        }
 
-	//*********************************************************************************************
-	// EQUALITY DEFINITIONS
-	//*********************************************************************************************
+        "square distance" - {
+          "should compute well" in { v squareDistanceTo u should equal(pow(v distanceTo u, 2)) }
+          "should be symmetric" in { v squareDistanceTo u should be(u squareDistanceTo v) }
+          "to Origin should be the square of the vector module" in { v squareDistanceTo Origin should equal(pow(v.module, 2)) }
+          "to self should be 0" in { v squareDistanceTo v should be(0.0) }
+        }
 
-	val tolerance = 0.00000001
+        "manhattan distance" - {
+          "should compute well" in { v manhattanDistanceTo u should be(values.manhattanDistance) }
+          "should be symmetric" in { v manhattanDistanceTo u should be(u manhattanDistanceTo v) }
+          "to self should be 0" in { v manhattanDistanceTo v should be(0.0) }
+        }
+      }
+    }
+  }
 
-	implicit val VectorEquality = new Equality[Vector] {
-		def areEqual(v: Vector, o: Any) = {
-			o match {
-				case (x: Number, y: Number) => x.doubleValue === v.x.doubleValue +- tolerance && y.doubleValue === v.y.doubleValue +- tolerance
-				case u: Vector => u.x.doubleValue === v.x.doubleValue +- tolerance && u.y.doubleValue === v.y.doubleValue +- tolerance
-				case _ => false
-			}
-		}
-	}
+  //*********************************************************************************************
+  // EQUALITY DEFINITIONS
+  //*********************************************************************************************
 
-	implicit val DoubleEquality = new Equality[Double] {
-		def areEqual(d: Double, o: Any) = {
-			o match {
-				case n : Double => d === n +- tolerance
-				case _ => false
-			}
-		}
-	}
+  val tolerance = 0.00000001
+
+  implicit val VectorEquality = new Equality[Vector] {
+    def areEqual(v: Vector, o: Any) = {
+      o match {
+        case (x: Number, y: Number) => x.doubleValue === v.x.doubleValue +- tolerance && y.doubleValue === v.y.doubleValue +- tolerance
+        case (x: Number, y: Number, z:Number) => x.doubleValue === v.x.doubleValue +- tolerance && y.doubleValue === v.y.doubleValue +- tolerance && z.doubleValue === v.z.doubleValue +- tolerance
+        case u: Vector              => u.x.doubleValue === v.x.doubleValue +- tolerance && u.y.doubleValue === v.y.doubleValue +- tolerance
+        case _                      => false
+      }
+    }
+  }
+
+  implicit val DoubleEquality = new Equality[Double] {
+    def areEqual(d: Double, o: Any) = {
+      o match {
+        case n: Double => d === n +- tolerance
+        case _         => false
+      }
+    }
+  }
 }


### PR DESCRIPTION
Agregué a Uqbar-Math soporte para Vectores 3D, de manera tal de no romper la API original y tratando de mantener el mismo nivel de performance. Agregué a su vez algunos métodos para consultar los vectores y operar con los vectores de manera genérica y usando los ejes. Creo que era lo que más queríamos de todo lo que habíamos hablado en su momento.

El concepto de Space lo deprequé momentáneamente hasta tener un caso de uso.

Mi intención es dejar ya esto como el resultado del laburo en UqbarMath y empezar a laburar en Cacao LWJGL, para después agregarle soporte 3D a Chocolate.

Avisame cualquier cosa!
